### PR TITLE
Disable ember analytics

### DIFF
--- a/.ember-cli
+++ b/.ember-cli
@@ -5,5 +5,5 @@
 
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
-  "disableAnalytics": false
+  "disableAnalytics": true
 }


### PR DESCRIPTION
ember-cli lets you choose whether to send analytics or not, whilst the
data sent is not sensitive and anonymous I see no reason to not disable
it.
